### PR TITLE
cinnamon-desktop: Update POTFILES.in

### DIFF
--- a/packages/cinnamon-desktop/cinnamon-desktop/cinnamon-desktop-2.4.2.exheres-0
+++ b/packages/cinnamon-desktop/cinnamon-desktop/cinnamon-desktop-2.4.2.exheres-0
@@ -49,7 +49,10 @@ DEPENDENCIES="
         sys-apps/pnp-data
 "
 
-DEFAULT_SRC_PREPARE_PATCHES=( "${FILES}"/${PNV}-gnome-3.14.patch )
+DEFAULT_SRC_PREPARE_PATCHES=(
+    "${FILES}"/${PNV}-gnome-3.14.patch
+    "${FILES}"/${PNV}-potfiles.patch
+)
 
 DEFAULT_SRC_CONFIGURE_PARAMS=(
     '--disable-schemas-compile'

--- a/packages/cinnamon-desktop/cinnamon-desktop/files/cinnamon-desktop-2.4.2-potfiles.patch
+++ b/packages/cinnamon-desktop/cinnamon-desktop/files/cinnamon-desktop-2.4.2-potfiles.patch
@@ -1,0 +1,28 @@
+From ab4b281031a20fa0ef9d21e391b14888f732739c Mon Sep 17 00:00:00 2001
+From: Fabio Fantoni <fantonifabio@tiscali.it>
+Date: Tue, 16 Dec 2014 12:26:04 +0100
+Subject: [PATCH] added missed entries in POTFILES.in
+
+Note:
+Probably also po files update will be good.
+---
+ po/POTFILES.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/po/POTFILES.in b/po/POTFILES.in
+index bce487b..37e8ad1 100644
+--- a/po/POTFILES.in
++++ b/po/POTFILES.in
+@@ -16,8 +16,12 @@ schemas/org.cinnamon.desktop.background.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.default-applications.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.input-sources.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.interface.gschema.xml.in.in
++schemas/org.cinnamon.desktop.keybindings.gschema.xml.in.in
++schemas/org.cinnamon.desktop.keybindings.media-keys.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.lockdown.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.media-handling.gschema.xml.in.in
++schemas/org.cinnamon.desktop.notifications.gschema.xml.in.in
++schemas/org.cinnamon.desktop.privacy.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.screensaver.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.session.gschema.xml.in.in
+ schemas/org.cinnamon.desktop.sound.gschema.xml.in.in


### PR DESCRIPTION
We need to apply the patch, otherwise test will fail.

Making check in po
make[1]: Entering directory '/var/tmp/paludis/build/cinnamon-desktop-cinnamon-desktop-2.4.2/work/cinnamon-desktop-2.4.2/po'
INTLTOOL_EXTRACT="/usr/bin/intltool-extract" XGETTEXT="/usr/bin/xgettext" srcdir=. /usr/bin/intltool-update --gettext-package cinnamon-desktop --pot
rm -f missing notexist
srcdir=. /usr/bin/intltool-update -m
The following files contain translations and are currently not in use. Please
consider adding these to the POTFILES.in file, located in the po/ directory.

schemas/org.cinnamon.desktop.keybindings.gschema.xml.in.in
schemas/org.cinnamon.desktop.keybindings.media-keys.gschema.xml.in.in
schemas/org.cinnamon.desktop.notifications.gschema.xml.in.in
schemas/org.cinnamon.desktop.privacy.gschema.xml.in.in
